### PR TITLE
Fix aside tags not rendering on blog page

### DIFF
--- a/blog/app/src/components/organisms/ArticleTemplate.tsx
+++ b/blog/app/src/components/organisms/ArticleTemplate.tsx
@@ -59,6 +59,15 @@ const ArticleTeplate: React.FC<Props> = ({ contentHtml }) => {
           </>
         )
       }
+      if (domNode instanceof Element && domNode.name === 'aside') {
+        return (
+          <>
+            <aside className="p-4 my-4 border-l-4 border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-900/20">
+              {domToReact(domNode.children, options)}
+            </aside>
+          </>
+        )
+      }
       if (domNode instanceof Element && domNode.name === 'a') {
         return (
           <>

--- a/blog/app/src/components/organisms/ArticleTemplate.tsx
+++ b/blog/app/src/components/organisms/ArticleTemplate.tsx
@@ -14,25 +14,16 @@ type Props = {
 }
 
 const ArticleTeplate: React.FC<Props> = ({ contentHtml }) => {
-  // HTMLエンティティをデコードする関数（SSR対応）
-  const decodeHtmlEntities = (html: string): string => {
-    const entities: { [key: string]: string } = {
-      '&amp;': '&',
-      '&lt;': '<',
-      '&gt;': '>',
-      '&quot;': '"',
-      '&#39;': "'",
-      '&#x27;': "'",
-      '&#x2F;': '/',
-    }
-    return html.replace(
-      /&(?:amp|lt|gt|quot|#39|#x27|#x2F);/g,
-      (match) => entities[match] || match,
-    )
+  // asideタグのみをデコードする関数（codeタグ内は保護）
+  const decodeAsideTags = (html: string): string => {
+    // &lt;aside&gt; と &lt;/aside&gt; だけを <aside> と </aside> にデコード
+    return html
+      .replace(/&lt;aside&gt;/g, '<aside>')
+      .replace(/&lt;\/aside&gt;/g, '</aside>')
   }
 
-  // HTMLエンティティをデコード
-  const decodedHtml = decodeHtmlEntities(contentHtml)
+  // asideタグをデコード
+  const decodedHtml = decodeAsideTags(contentHtml)
 
   const options: HTMLReactParserOptions = {
     replace: (domNode) => {

--- a/blog/app/src/components/organisms/ArticleTemplate.tsx
+++ b/blog/app/src/components/organisms/ArticleTemplate.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import hilight from 'highlight.js'
 import parse, {
   Element,
+  Text,
   domToReact,
   HTMLReactParserOptions,
 } from 'html-react-parser'
@@ -113,8 +114,8 @@ const ArticleTeplate: React.FC<Props> = ({ contentHtml }) => {
         ]
         // テキストノードからテキストを直接抽出
         const codeText = domNode.children
-          .map((child: any) => {
-            if (child.type === 'text') {
+          .map((child) => {
+            if (child instanceof Text) {
               return child.data
             }
             return ''

--- a/blog/app/src/components/organisms/ArticleTemplate.tsx
+++ b/blog/app/src/components/organisms/ArticleTemplate.tsx
@@ -13,14 +13,15 @@ type Props = {
 }
 
 const ArticleTeplate: React.FC<Props> = ({ contentHtml }) => {
-  // デバッグ: asideタグの確認
-  if (contentHtml.includes('aside')) {
-    console.log('=== DEBUG: HTML content with aside ===')
-    console.log(contentHtml.substring(
-      Math.max(0, contentHtml.indexOf('aside') - 50),
-      Math.min(contentHtml.length, contentHtml.indexOf('aside') + 200)
-    ))
+  // HTMLエンティティをデコードする関数
+  const decodeHtmlEntities = (html: string): string => {
+    const txt = document.createElement('textarea')
+    txt.innerHTML = html
+    return txt.value
   }
+
+  // HTMLエンティティをデコード
+  const decodedHtml = decodeHtmlEntities(contentHtml)
 
   const options: HTMLReactParserOptions = {
     replace: (domNode) => {
@@ -109,7 +110,7 @@ const ArticleTeplate: React.FC<Props> = ({ contentHtml }) => {
       }
     },
   }
-  return <>{parse(contentHtml, options)}</>
+  return <>{parse(decodedHtml, options)}</>
 }
 
 export default ArticleTeplate

--- a/blog/app/src/components/organisms/ArticleTemplate.tsx
+++ b/blog/app/src/components/organisms/ArticleTemplate.tsx
@@ -13,6 +13,15 @@ type Props = {
 }
 
 const ArticleTeplate: React.FC<Props> = ({ contentHtml }) => {
+  // デバッグ: asideタグの確認
+  if (contentHtml.includes('aside')) {
+    console.log('=== DEBUG: HTML content with aside ===')
+    console.log(contentHtml.substring(
+      Math.max(0, contentHtml.indexOf('aside') - 50),
+      Math.min(contentHtml.length, contentHtml.indexOf('aside') + 200)
+    ))
+  }
+
   const options: HTMLReactParserOptions = {
     replace: (domNode) => {
       if (domNode instanceof Element && domNode.name === 'h1') {

--- a/blog/app/src/components/organisms/ArticleTemplate.tsx
+++ b/blog/app/src/components/organisms/ArticleTemplate.tsx
@@ -95,7 +95,7 @@ const ArticleTeplate: React.FC<Props> = ({ contentHtml }) => {
             <a
               {...domNode.attribs}
               rel="noreferrer"
-              className="text-sky-500 px-1 py-2"
+              className="text-sky-500 px-1 py-2 break-words"
             >
               {domToReact(domNode.children)}
             </a>

--- a/blog/app/src/components/organisms/ArticleTemplate.tsx
+++ b/blog/app/src/components/organisms/ArticleTemplate.tsx
@@ -13,11 +13,21 @@ type Props = {
 }
 
 const ArticleTeplate: React.FC<Props> = ({ contentHtml }) => {
-  // HTMLエンティティをデコードする関数
+  // HTMLエンティティをデコードする関数（SSR対応）
   const decodeHtmlEntities = (html: string): string => {
-    const txt = document.createElement('textarea')
-    txt.innerHTML = html
-    return txt.value
+    const entities: { [key: string]: string } = {
+      '&amp;': '&',
+      '&lt;': '<',
+      '&gt;': '>',
+      '&quot;': '"',
+      '&#39;': "'",
+      '&#x27;': "'",
+      '&#x2F;': '/',
+    }
+    return html.replace(
+      /&(?:amp|lt|gt|quot|#39|#x27|#x2F);/g,
+      (match) => entities[match] || match,
+    )
   }
 
   // HTMLエンティティをデコード

--- a/blog/app/src/components/organisms/ArticleTemplate.tsx
+++ b/blog/app/src/components/organisms/ArticleTemplate.tsx
@@ -111,10 +111,17 @@ const ArticleTeplate: React.FC<Props> = ({ contentHtml }) => {
           'python',
           'php',
         ]
-        const hilightCode = hilight.highlightAuto(
-          domToReact(domNode.children) as string,
-          languageSubset,
-        )
+        // テキストノードからテキストを直接抽出
+        const codeText = domNode.children
+          .map((child: any) => {
+            if (child.type === 'text') {
+              return child.data
+            }
+            return ''
+          })
+          .join('')
+
+        const hilightCode = hilight.highlightAuto(codeText, languageSubset)
         const dom = parse(hilightCode.value)
         return <code className="hljs">{dom}</code>
       }


### PR DESCRIPTION
Add support for <aside> HTML tags in ArticleTemplate component. Previously, aside tags were being displayed as plain text instead of being rendered as HTML elements. This fix adds proper handling with appropriate styling (blue left border, light background) that works in both light and dark modes.