### PR TITLE
fix: Lottie アイコンの枠を 16:9 にしヘッダー高さの膨張を解消

### DIFF
--- a/blog/app/src/components/layout/Header.tsx
+++ b/blog/app/src/components/layout/Header.tsx
@@ -56,7 +56,7 @@ const Header: React.FC = ({}) => {
               </div>
             </div>
             <div className="flex items-center gap-4">
-              <LottieIcon src={DOG_LOTTIE_SRC} className="w-24 h-24 -mr-7" />
+              <LottieIcon src={DOG_LOTTIE_SRC} className="w-24 h-14 -mr-7" />
               <ThemeToggle />
               <div className="md:hidden">
                 <button


### PR DESCRIPTION
正方形枠(h-24)の上下レターボックスでヘッダーが縦に膨らんでいたため、
枠を素材比率に合わせ w-24 h-14 に変更（犬の見た目サイズは維持）。