### PR TITLE
feat: UIの変更(スマホでの記事はみ出し修正を含む)

### DIFF
--- a/blog/app/src/pages/articles/[id].tsx
+++ b/blog/app/src/pages/articles/[id].tsx
@@ -40,7 +40,7 @@ const ArticlesId: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
           </div>
         </div>
       )}
-      <main className="py-8 md:w-3/5 mx-auto">
+      <main className="py-8 w-full md:w-3/5 mx-auto">
         <h1 className="text-center text-3xl font-bold my-3 ">{article.title}</h1>
         <p className="text-right mt-3 mb-9 font-mono text-sm text-ink-400 dark:text-ink-400">
           {formatUTCtoJST(article.publishedAt)}


### PR DESCRIPTION
## 概要
- サイト全体のUIを刷新(ヘッダー/フッター/カード/ページネーション/トップページ 等)
- UI刷新で発生したスマホ表示の不具合を修正:Container の flex 化により、mx-auto 付きの main が shrink-to-fit でコードブロックの max-content 幅(986px)まで広がり、記事全体が画面外にはみ出していた。main に w-full を追加して解消

## テスト
- Playwright で全記事をモバイル幅(375px)で機械チェックし、はみ出し要素ゼロを確認
- コードブロックは .hljs の overflow-x: auto によりブロック内横スクロールになることを確認
- デスクトップ幅(1280px)では md:w-3/5 が維持され、レイアウト変化なしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)